### PR TITLE
Add assertEqualDiff* functions and update dependencies

### DIFF
--- a/HUnit-Diff.cabal
+++ b/HUnit-Diff.cabal
@@ -1,5 +1,5 @@
 Name:                HUnit-Diff
-Version:             0.1
+Version:             0.1.1
 Synopsis:            Assertions for HUnit with difference reporting
 Description:         HUnit assertion operators that show a diff on failure.
 Homepage:            https://github.com/dag/HUnit-Diff
@@ -18,8 +18,8 @@ Source-Repository head
 
 Library
   Exposed-modules:     Test.HUnit.Diff
-  Build-depends:       ansi-terminal == 0.5.*,
+  Build-depends:       ansi-terminal >= 0.5 && < 0.7,
                        base == 4.*,
-                       Diff == 0.1.*,
+                       Diff == 0.3.*,
                        groom == 0.1.*,
-                       HUnit == 1.2.*
+                       HUnit >= 1.2 && < 1.4

--- a/Test/HUnit/Diff.hs
+++ b/Test/HUnit/Diff.hs
@@ -1,4 +1,9 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ImplicitParams #-}
 {- | Very basic support for diffing with HUnit.
+
+Supports both line diffs using 'groom' and word diffs.
+Unexpected additions are marked with +red, and delections from expected are -green.
 
 Limitations:
 
@@ -15,31 +20,129 @@ Limitations:
 Despite these limitations, I find it more useful than HUnit's defaults.
 
 -}
-module Test.HUnit.Diff ((@?==), (@==?)) where
+module Test.HUnit.Diff ( assertEqualDiffGroomUnified, assertEqualDiffGroom
+                       , assertEqualDiffWordUnified,  assertEqualDiffWord
+                       , (@?==), (@==?) ) where
 
-import Data.Functor        ( (<$>) )
+import Control.Monad       ( unless, ap )
+import Data.Char           ( isSpace )
 
-import Data.Algorithm.Diff ( getDiff, DI(B, F, S) )
+import Data.Algorithm.Diff ( getGroupedDiff, Diff(First, Second, Both) )
 import System.Console.ANSI ( Color(Green, Red), ColorIntensity(Dull)
                            , ConsoleLayer(Foreground), SGR(SetColor, Reset)
                            , setSGRCode )
-import Test.HUnit          ( Assertion, assertBool, (@?=), (@=?) )
+import Test.HUnit          ( Assertion, assertFailure )
 import Text.Groom          ( groom )
 
--- | Like '@?=' but producing a colored diff on failure.
-(@?==) :: (Eq a, Show a) => a -> a -> Assertion
-x @?== y =
-    assertBool ('\n':msg) (x == y)
-  where
-    msg       = unlines $ fmt <$> getDiff (lines . groom $ x)
-                                          (lines . groom $ y)
-    fmt (B,s) =               ' ' : s
-    fmt (F,s) = color Green $ '+' : s
-    fmt (S,s) = color Red   $ '-' : s
-    color c s = setSGRCode [SetColor Foreground Dull c]
-                ++ s ++
-                setSGRCode [Reset]
+#if MIN_VERSION_base(4,8,1)
+import GHC.Stack
+#define with_loc (?loc :: CallStack) =>
+#else
+#define with_loc
+#endif
 
--- | Like '@=?' but producing a colored diff on failure.
+color :: Color -> String -> String
+color c s = setSGRCode [SetColor Foreground Dull c]
+  ++ s ++ setSGRCode [Reset]
+
+colorDiff :: Diff a -> String -> String
+colorDiff (Both _ _) = id
+colorDiff (First _)  = color Green
+colorDiff (Second _) = color Red
+
+assertEqualWithDiff :: with_loc (Eq a, Show a)
+                              => (a -> [String])
+                              -> ([Diff [String]] -> String)
+                              -> String -> a -> a -> Assertion
+assertEqualWithDiff items msgfmt preface expected actual =
+  unless (actual == expected) $ assertFailure $
+    (if null preface then "" else preface ++ "\n") ++
+    (msgfmt $ getGroupedDiff (items expected)
+                             (items actual))
+
+assertEqualWithDiffUnified :: with_loc (Eq a, Show a)
+                              => (a -> [String])
+                              -> (Diff [String] -> String)
+                              -> String -> a -> a -> Assertion
+assertEqualWithDiffUnified sp jn =
+  assertEqualWithDiff sp $ concatMap $ colorDiff `ap` jn
+
+assertEqualWithDiffSplit :: with_loc (Eq a, Show a)
+                              => (a -> [String])
+                              -> (Diff [String] -> String)
+                              -> String -> a -> a -> Assertion
+assertEqualWithDiffSplit sp jn =
+  assertEqualWithDiff sp $ \diff ->
+      "expected: " ++ fmt msk1 diff ++
+    "\n but got: " ++ fmt msk2 diff
+ where
+  fmt msk = concatMap $ msk $ colorDiff `ap` jn
+  msk1 _ (Second _) = ""
+  msk1 f d          = f d
+  msk2 f (Both _ s) = f (Both s s)
+  msk2 _ (First  _) = ""
+  msk2 f d          = f d
+
+unlines' :: [String] -> String
+unlines' [] = ""
+unlines' (s:l) = '\n':s ++ unlines' l
+
+formatLine :: Diff [String] -> [String]
+formatLine (Both s _) = map (' ' :) s
+formatLine (First s)  = map ('-' :) s
+formatLine (Second s) = map ('+' :) s
+
+-- |Like 'Text.HUnit.assertEqual' but producing a colored, unified 'groom'ed line diff on failure.
+assertEqualDiffGroomUnified :: with_loc (Eq a, Show a)
+                              => String -- ^ The message prefix
+                              -> a      -- ^ The expected value
+                              -> a      -- ^ The actual value
+                              -> Assertion
+assertEqualDiffGroomUnified =
+  assertEqualWithDiffUnified (lines . groom) (unlines' . formatLine)
+
+-- |Like 'Text.HUnit.assertEqual' but producing colored 'groom'ed line diff on failure.
+assertEqualDiffGroom :: with_loc (Eq a, Show a)
+                              => String -- ^ The message prefix
+                              -> a      -- ^ The expected value
+                              -> a      -- ^ The actual value
+                              -> Assertion
+assertEqualDiffGroom =
+  assertEqualWithDiffSplit (lines . groom) (unlines' . formatLine)
+
+splitWords :: String -> [String]
+splitWords "" = []
+splitWords s = (sw++ss') : splitWords sr where
+  (sw,ss) = break isSpace s
+  (ss',sr) = span isSpace ss
+
+formatWords :: Diff [String] -> String
+formatWords (Both s _) = concat s
+formatWords (First s)  = "{-" ++ concat s ++ "-}"
+formatWords (Second s) = "{+" ++ concat s ++ "+}"
+
+-- |Like 'Text.HUnit.assertEqual' but producing a colored, unified character diff on failure.
+assertEqualDiffWordUnified :: with_loc (Eq a, Show a)
+                              => String -- ^ The message prefix
+                              -> a      -- ^ The expected value
+                              -> a      -- ^ The actual value
+                              -> Assertion
+assertEqualDiffWordUnified =
+  assertEqualWithDiffUnified (splitWords . show) formatWords
+
+-- |Like 'Text.HUnit.assertEqual' but producing a colored character diff on failure.
+assertEqualDiffWord :: with_loc (Eq a, Show a)
+                              => String -- ^ The message prefix
+                              -> a      -- ^ The expected value
+                              -> a      -- ^ The actual value
+                              -> Assertion
+assertEqualDiffWord =
+  assertEqualWithDiffSplit (splitWords . show) formatWords
+
+-- | Like 'Test.HUnit.@?=' but producing a colored diff on failure using 'assertEqualDiffGroomUnified'.
+(@?==) :: (Eq a, Show a) => a -> a -> Assertion
+actual @?== expected = assertEqualDiffGroomUnified "" expected actual
+
+-- | Like 'Test.HUnit.@=?' but producing a colored diff on failure using 'assertEqualDiffGroomUnified'.
 (@==?) :: (Eq a, Show a) => a -> a -> Assertion
-y @==? x = x @?== y
+expected @==? actual = assertEqualDiffGroomUnified "" expected actual


### PR DESCRIPTION
This adds a number of assertEqual-like functions with more diff modes: the current groomed line diff and a word diff that's more similar to the default display.  It maintains the two original functions pretty much exactly, though. Update/loosen dependencies to current versions.

One debatable change is that I changed colors/indicators to make more sense to me, even though they no longer match normal diff coloring: `+`red means unexpected additions and `-`green means expected but missing.

Bump version to 0.1.1 for amended API.

Happy to take suggestions.
